### PR TITLE
Fix error display

### DIFF
--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -74,7 +74,7 @@
         {% endfor %}
       {% endif %}
 
-      <p>{{ form.errors }}</p>
+      <p>{{ form.non_field_errors }}</p>
 
       {% block content %}{% endblock %}
     </main>


### PR DESCRIPTION
The formerly used method is meant to be used in a loop, caused error messages to be displayed below a "__all__" list item