### PR TITLE
load static instead of load staticfiles

### DIFF
--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!doctype html>
 <html lang="en">
   <head>


### PR DESCRIPTION
I can't seem to find why `load static` is recommended now, but I got a deprecation warning from `load staticfiles`. 🤷‍♂ 